### PR TITLE
Hide next meeting on dashboard

### DIFF
--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -113,19 +113,19 @@ export default function AboutPage(): React.ReactElement {
 		};
 		icon: string;
 	}[] = [
-		{
-			subtitle: "Next Member Meeting",
-			title: nextMeeting,
-			primaryAction: {
-				title: "Join Meeting",
-				link: "/zoom",
-			},
-			secondaryAction: {
-				title: "View All Events",
-				link: "/calendar",
-			},
-			icon: "UserGroup",
-		},
+		// {
+		// 	subtitle: "Next Member Meeting",
+		// 	title: nextMeeting,
+		// 	primaryAction: {
+		// 		title: "Join Meeting",
+		// 		link: "/zoom",
+		// 	},
+		// 	secondaryAction: {
+		// 		title: "View All Events",
+		// 		link: "/calendar",
+		// 	},
+		// 	icon: "UserGroup",
+		// },
 
 		//{
 		//	subtitle: "Registration Now Open",
@@ -294,7 +294,7 @@ export default function AboutPage(): React.ReactElement {
 																	.primaryAction
 																	.link
 															}
-															className="font-medium text-cyan-700 hover:text-cyan-900"
+															className="font-medium text-indigo-700 hover:text-indigo-900"
 														>
 															{
 																card


### PR DESCRIPTION
There are no more meetings on the calendar right now so I just commented out the code for the next meeting card

(Less importantly, I also changed the card action link color to indigo to match the rest of the site)